### PR TITLE
added Dunfell

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "opendds-layer"
 BBFILE_PATTERN_opendds-layer = "^${LAYERDIR}/"
 BBFILE_PRIORITY_opendds-layer = "6"
 
-LAYERSERIES_COMPAT_opendds-layer = "thud warrior zeus"
+LAYERSERIES_COMPAT_opendds-layer = "thud warrior zeus dunfell"
 LAYERDEPENDS_opendds-layer = "core"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"


### PR DESCRIPTION
Added the 3.1 LTS Yocto release 'Dunfell'.

Added opendds to the core-image-minimal without any issues.