### PR TITLE
Add copy of MPC_ROOT folder to target /usr/share/MPC

### DIFF
--- a/recipes-connectivity/opendds/opendds.inc
+++ b/recipes-connectivity/opendds/opendds.inc
@@ -98,6 +98,10 @@ do_install:append:class-target() {
             done
         fi
     done
+
+    # Copy MPC_ROOT folder to sysroot-destdir/usr/share/MPC
+    . ${S}/setenv.sh
+    cp -r ${MPC_ROOT} ${D}${datadir}/MPC
 }
 
 do_install:append:class-native() {


### PR DESCRIPTION
Add copy MPC_ROOT folder of OpenDDS source tree to target recipe-sysroot/usr/share/MPC.
This supports the building of OpenDDS applications MPC projects that depend on this layer.
 