### PR TITLE
Moved the variable ACE_TAO_OPTION to the packageconfig 'doc-group3'

### DIFF
--- a/README
+++ b/README
@@ -40,10 +40,11 @@ The layer contains two recipes for OpenDDS: one versioned and one not.
 If PREFERRED_VERSION is not specifed in your local.conf then the OpenDDS 3.26.1 recipe will be
 selected for build by default
 
-The versioned recipe will download and build with DOC Group ACE/TAO v2 by default.
+The versioned recipe will use the DOC Group ACE/TAO v2 by default.
 To build the versioned recipe with DOC Group ACE/TAO v3 add the following to your local.conf
     
-    ACE_TAO_OPTION = "--doc-group3"
+    PACKAGECONFIG:append:pn-opendds = " doc-group3"
+    PACKAGECONFIG:append:pn-opendds-native = " doc-group3"
   
 The unversioned recipe is provided to allow clients, via a bbappend, to
 build - for example - the HEAD of the master branch or some other version.

--- a/recipes-connectivity/opendds/opendds.inc
+++ b/recipes-connectivity/opendds/opendds.inc
@@ -8,7 +8,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=11ee76f6fb51f69658b5bb8327c50b11"
 inherit autotools
 
 PACKAGECONFIG ??= ""
+PACKAGECONFIG:class-native ??= ""
 PACKAGECONFIG[ishapes] = "--qt=${STAGING_DIR_NATIVE}${prefix_native} --qt-include=${STAGING_INCDIR},,qtbase qtbase-native"
+PACKAGECONFIG[doc-group3] = "--doc-group3,,"
 
 DEPENDS += "\
     cmake-native \
@@ -60,14 +62,13 @@ OECONF:append = "\
     --security \
     --openssl=${WORKDIR}/recipe-sysroot/usr \
     --xerces3=${WORKDIR}/recipe-sysroot/usr \
-    ${ACE_TAO_OPTION} \
+    ${PACKAGECONFIG_CONFARGS} \
 "
 
 OECONF:append:class-target = "\
     --host-tools=${STAGING_BINDIR_NATIVE}/DDS_HOST_ROOT \
     --target=linux-cross \
     --target-compiler=${S}/${HOST_PREFIX}g++ \
-    ${PACKAGECONFIG_CONFARGS} \
 "
 OECONF:append:class-native = "\
     --target=linux \

--- a/recipes-connectivity/opendds/opendds_3.27.0.bb
+++ b/recipes-connectivity/opendds/opendds_3.27.0.bb
@@ -1,14 +1,3 @@
-# Specify SHA-1 for the release to avoid constantly checking the upstream repo.
-
-SRCREV = "6415d1750a65051fb1ee1c39a99a0915b7d3755b"
-DDS_SRC_BRANCH = "branch-DDS-3.27"
-SRC_URI = "\
-    git://github.com/OpenDDS/OpenDDS.git;protocol=https;branch=${DDS_SRC_BRANCH};name=opendds \
-    ${@bb.utils.contains('PACKAGECONFIG', 'ishapes', 'file://0001-adding-the-ishapes-demo.patch', '', d)} \
-"
-
-require opendds.inc
-
 DOC_TAO2_VERSION = "6.5.20"
 DOC_TAO3_VERSION = "7.1.3"
 
@@ -18,15 +7,14 @@ DOC_TAO3_SHA256SUM = "7d394cfcc71d0e90824fd1399f93640b4c9423016b88974ad3e4694c53
 DOC_TAO2_URI = "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE+TAO-${@'${DOC_TAO2_VERSION}'.replace('.','_')}/ACE+TAO-src-${DOC_TAO2_VERSION}.tar.gz"
 DOC_TAO3_URI = "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE+TAO-${@'${DOC_TAO3_VERSION}'.replace('.','_')}/ACE+TAO-src-${DOC_TAO3_VERSION}.tar.gz"
 
-ACE_TAO_OPTION ??= ""
-ACE_TAO_URI ??= "${DOC_TAO2_URI}"
-ACE_TAO_SHA256SUM ??= "${DOC_TAO2_SHA256SUM}"
+DDS_SRC_BRANCH = "branch-DDS-3.27"
+SRC_URI = "\
+    git://github.com/OpenDDS/OpenDDS.git;protocol=https;branch=${DDS_SRC_BRANCH};name=opendds \
+    ${@bb.utils.contains('PACKAGECONFIG', 'doc-group3', '${DOC_TAO3_URI};name=ace_tao;unpack=0;subdir=git', '${DOC_TAO2_URI};name=ace_tao;unpack=0;subdir=git', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'ishapes', 'file://0001-adding-the-ishapes-demo.patch', '', d)} \
+"
 
-python () {
-    if d.getVar('ACE_TAO_OPTION') == '--doc-group3':
-        d.setVar('ACE_TAO_URI', '${DOC_TAO3_URI}')
-        d.setVar('ACE_TAO_SHA256SUM', '${DOC_TAO3_SHA256SUM}')
-}
+require opendds.inc
 
-SRC_URI += "${ACE_TAO_URI};name=ace_tao;unpack=0;subdir=git"
-SRC_URI[ace_tao.sha256sum] = "${ACE_TAO_SHA256SUM}"
+SRCREV = "6415d1750a65051fb1ee1c39a99a0915b7d3755b"
+SRC_URI[ace_tao.sha256sum] = "${@bb.utils.contains('PACKAGECONFIG', 'doc-group3', '${DOC_TAO3_SHA256SUM}', '${DOC_TAO2_SHA256SUM}', d)}"

--- a/recipes-connectivity/opendds/opendds_git.bb
+++ b/recipes-connectivity/opendds/opendds_git.bb
@@ -17,11 +17,9 @@ PV = "1.0+git${SRCPV}"
 DDS_SRC_BRANCH ??= "master"
 SRC_URI = "git://github.com/objectcomputing/OpenDDS.git;protocol=https;branch=${DDS_SRC_BRANCH}"
 
-OECONF = "\
+OECONF:append = "\
     --ace-github-latest \
 "
-
-ACE_TAO_OPTION = ""
 
 do_configure[network] = "1"
 


### PR DESCRIPTION
A rather small PR to change the variable to decide if the docgroup v2 or v3 is used into a package config.
This is a more Yocto way of doing the same.

The selection to use ACE_TAO version 2 or 3 is is now in the packageconfig 'doc-group3'.
Default the version 2 is used.  As it is in the configuration of OpenDDS.

Although the syntax was correct before,  using variables is tainting the global namespace of Yocto.
And using a packageconfig is more the yocto way.