### PR TITLE
layer.conf: added the new Scarthgap release

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "opendds-layer"
 BBFILE_PATTERN_opendds-layer = "^${LAYERDIR}/"
 BBFILE_PRIORITY_opendds-layer = "6"
 
-LAYERSERIES_COMPAT_opendds-layer = "kirkstone nanbield"
+LAYERSERIES_COMPAT_opendds-layer = "kirkstone nanbield scarthgap"
 LAYERDEPENDS_opendds-layer = "core"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"


### PR DESCRIPTION
The Nanbield and Kirkstone releases are still supported.