### PR TITLE
adding kas and ptest

### DIFF
--- a/.github/scripts/yocto-check-layer.sh
+++ b/.github/scripts/yocto-check-layer.sh
@@ -14,4 +14,7 @@ cd poky
 git clone --depth 1 --branch $YOCTO_RELEASE git://git.openembedded.org/meta-openembedded
 . ./oe-init-build-env build
 bitbake-layers add-layer ../meta-openembedded/meta-oe
+bitbake-layers add-layer ../meta-openembedded/meta-perl
+bitbake-layers add-layer ../meta-openembedded/meta-python
+bitbake-layers add-layer ../meta-openembedded/meta-networking
 yocto-check-layer --with-software-layer-signature-check --debug "$GITHUB_WORKSPACE"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .project
 
+# kas
+build/
+layers/

--- a/README
+++ b/README
@@ -6,10 +6,10 @@ Dependencies
 ============
 
   URI: git://git.openembedded.org/meta-openembedded
-  branch: kirkstone
+  branch: scarthgap
 
   URI:  https://git.yoctoproject.org/git/poky/meta
-  branch: kirkstone
+  branch: scarthgap
 
 Patches
 =======
@@ -37,7 +37,7 @@ II. Misc
 
 The layer contains two recipes for OpenDDS: one versioned and one not.
 
-If PREFERRED_VERSION is not specifed in your local.conf then the OpenDDS 3.26.1 recipe will be
+If PREFERRED_VERSION is not specifed in your local.conf then the OpenDDS 3.28.0 recipe will be
 selected for build by default
 
 The versioned recipe will use the DOC Group ACE/TAO v2 by default.

--- a/kas/README.md
+++ b/kas/README.md
@@ -1,0 +1,60 @@
+Building OpenDDS with Yocto and Kas
+===================================
+
+[Kas](https://kas.readthedocs.io/en/latest/index.html) is a setup tool for bitbake based projects.
+
+Prerequisits
+------------
+
+# Kas installed
+
+See: https://kas.readthedocs.io/en/latest/userguide.html#dependencies-installation
+
+# Install bmap-tool to create the SDCard
+
+```
+apt install bmap-tools
+```
+
+# clone the OpenDDS Yocto layer
+
+```
+git clone https://github.com/OpenDDS/meta-opendds.git
+```
+
+Building
+--------
+
+```
+cd meta-opendds
+kas build kas/rpi.yaml; # Just OpenDDS for RPi
+kas build kas/rpi.yaml:kas/ishapes.yaml; # iShapes demo
+kas build kas/rpi.yaml:kas/ptests.yaml; # OpenDDS with Yocto ptests
+```
+
+Deploying
+---------
+
+Copy the WIC artifact to an SDCard.
+
+Following instruction is an *example*.  Check before executing the command where the SDCard is mounted (e.g. `/dev/sda`)!
+
+```
+cd build/tmp/deploy/images/raspberrypi4-64
+sudo bmaptool copy core-image-minimal-xfce-raspberrypi4-64.rootfs.wic.bz2 /dev/sda
+```
+
+Testing
+-------
+
+### Run the ishapes demo
+
+Open a terminal on the Raspberry Pi.
+Run `ishapes`
+
+### Running the Yocto ptests for OpenDDS
+
+Open a terminal on the Raspberry Pi.
+Run `ptest-runner opendds`
+
+A detailed log of the run can be found on the `/tmp` of the device.

--- a/kas/ishapes.yaml
+++ b/kas/ishapes.yaml
@@ -1,0 +1,14 @@
+header:
+    version: 1
+
+repos:
+    meta-qt5:
+        url: https://github.com/meta-qt5/meta-qt5/
+        path: layers/meta-qt5
+        branch: master  # Scartgap release not yet available
+
+local_conf_header:
+    opendds-ishapes: |
+        IMAGE_INSTALL:append = " opendds-ishapes"
+        PACKAGECONFIG:append:pn-opendds = " ishapes"
+        DISTRO_FEATURES:remove = " ptest"

--- a/kas/local.yaml
+++ b/kas/local.yaml
@@ -1,0 +1,13 @@
+header:
+    version: 1
+
+local_conf_header:
+    pc: |
+        PARALLEL_MAKE = "-j 4"
+        BB_NUMBER_THREADS = "4"
+    build_faster: |
+        DL_DIR = "/var/lib/yocto/downloads"
+        SSTATE_DIR = "/var/lib/yocto/sstate-cache"
+    buildhistory: |
+        INHERIT += "buildhistory"
+        BUILDHISTORY_COMMIT = "1"

--- a/kas/ptest.yaml
+++ b/kas/ptest.yaml
@@ -1,0 +1,8 @@
+header:
+    version: 1
+
+local_conf_header:
+    opendds-testing: |
+        DISTRO_FEATURES:append = " ptest"
+        EXTRA_IMAGE_FEATURES += "ptest-pkgs"
+        IMAGE_INSTALL:append = " opendds-dev"

--- a/kas/rpi.yaml
+++ b/kas/rpi.yaml
@@ -1,0 +1,70 @@
+header:
+    version: 1
+
+machine: raspberrypi4-64
+
+distro: poky
+
+target: core-image-minimal-xfce
+
+repos:
+    meta-opendds:
+    meta-raspberrypi:
+        url: https://github.com/agherzan/meta-raspberrypi
+        path: layers/meta-raspberrypi
+        branch: master  # Scartgap release not yet available
+    poky:
+        url: https://git.yoctoproject.org/git/poky
+        path: layers/poky
+        branch: scarthgap
+        layers:
+            meta:
+            meta-poky:
+    meta-openembedded:
+        url: http://git.openembedded.org/meta-openembedded
+        path: layers/meta-openembedded
+        branch: scarthgap
+        layers:
+            meta-oe:
+            meta-python:
+            meta-networking:
+            meta-perl:
+            meta-gnome:
+            meta-multimedia:
+            meta-xfce:
+
+bblayers_conf_header:
+    standard: |
+        POKY_BBLAYERS_CONF_VERSION = "2"
+        BBPATH = "${TOPDIR}"
+        BBFILES ?= ""
+
+local_conf_header:
+    standard: |
+        CONF_VERSION = "2"
+        SDKMACHINE = "x86_64"
+        USER_CLASSES = "buildstats"
+    debug-tweaks: |
+        EXTRA_IMAGE_FEATURES = "debug-tweaks"
+        IMAGE_ROOTFS_EXTRA_SPACE = "1524288"
+    diskmon: |
+        BB_DISKMON_DIRS = "\
+            STOPTASKS,${TMPDIR},1G,100K \
+            STOPTASKS,${DL_DIR},1G,100K \
+            STOPTASKS,${SSTATE_DIR},1G,100K \
+            STOPTASKS,/tmp,100M,100K \
+            HALT,${TMPDIR},100M,1K \
+            HALT,${DL_DIR},100M,1K \
+            HALT,${SSTATE_DIR},100M,1K \
+            HALT,/tmp,10M,1K"
+    network: |
+        IMAGE_FEATURES:append = " ssh-server-openssh"
+        hostname:pn-base-files = "rpi4-opendds"
+    system: |
+        DISTRO_FEATURES:append = " systemd usrmerge"
+        VIRTUAL-RUNTIME_init_manager = "systemd"
+    opendds: |
+        IMAGE_INSTALL:append = " opendds"
+        PACKAGECONFIG:append:pn-opendds = " doc-group3"
+        PACKAGECONFIG:append:pn-opendds-native = " doc-group3"
+        INHERIT += "cve-check"

--- a/recipes-connectivity/opendds/opendds.inc
+++ b/recipes-connectivity/opendds/opendds.inc
@@ -5,13 +5,16 @@ BUGTRACKER = "https://github.com/OpenDDS/OpenDDS/issues"
 LICENSE = "OpenDDS"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=11ee76f6fb51f69658b5bb8327c50b11"
 
-inherit autotools
+inherit autotools ptest
 
-PACKAGECONFIG ??= "security"
+SRC_URI:append = " file://run-ptest"
+
+PACKAGECONFIG ??= "security ${@bb.utils.contains('DISTRO_FEATURES', 'ptest', 'tests', '', d)}"
 PACKAGECONFIG:class-native ??= ""
 PACKAGECONFIG[security] = "--security, , openssl xerces-c, "
 PACKAGECONFIG[ishapes] = "--qt=${STAGING_DIR_NATIVE}${prefix_native} --qt-include=${STAGING_INCDIR},,qtbase qtbase-native"
 PACKAGECONFIG[doc-group3] = "--doc-group3,,"
+PACKAGECONFIG[tests] = "--tests --gtest=${WORKDIR}/recipe-sysroot/usr, --no-tests, googletest, perl packagegroup-meta-perl perl-module-tie-array perl-module-english, ,ishapes"
 
 DEPENDS += "\
     cmake-native \
@@ -56,7 +59,6 @@ OECONF ??= ""
 OECONF:append = "\
     --prefix=${prefix} \
     --verbose \
-    --no-tests \
     --no-rapidjson \
     ${PACKAGECONFIG_CONFARGS} \
 "
@@ -142,6 +144,69 @@ do_install:append:class-nativesdk() {
     ln -sf ${bindir}/tao_idl ${D}${datadir}/ace/bin/tao_idl
 }
 
+do_install_ptest() {
+    sed -i "s#@PTEST_ARGS@#${@bb.utils.contains('PACKAGECONFIG', 'security', '--security', '', d)}#g" ${D}${PTEST_PATH}/run-ptest
+
+    install -d ${D}${datadir}/DDS_ROOT/
+    install -d ${D}${datadir}/DDS_ROOT/tests
+    cd ${S}/tests
+    tar --no-same-owner \
+        --exclude='*.mpc'\
+        --exclude='*.o' \
+        --exclude='GNUmakefile*'\
+        --exclude='.gitignore'\
+        --exclude='.depend*'\
+        --exclude='.obj*'\
+        -cpf - . \
+        | tar --no-same-owner -xpf - -C ${D}${datadir}/DDS_ROOT/tests
+
+    install -d ${D}${datadir}/DDS_ROOT/performance-tests
+    cd ${S}/performance-tests
+    tar --no-same-owner \
+        --exclude='*.mpc'\
+        --exclude='*.o' \
+        --exclude='GNUmakefile*'\
+        --exclude='.gitignore'\
+        --exclude='.depend*'\
+        --exclude='.obj*'\
+        -cpf - . \
+        | tar --no-same-owner -xpf - -C ${D}${datadir}/DDS_ROOT/performance-tests
+
+    install -d ${D}${datadir}/DDS_ROOT/DevGuideExamples
+    cd ${S}/DevGuideExamples
+    tar --no-same-owner \
+        --exclude='*.mpc'\
+        --exclude='*.o' \
+        --exclude='GNUmakefile*'\
+        --exclude='.gitignore'\
+        --exclude='.depend*'\
+        --exclude='.obj*'\
+        -cpf - . \
+        | tar --no-same-owner -xpf - -C ${D}${datadir}/DDS_ROOT/DevGuideExamples
+
+    install -d ${D}${datadir}/DDS_ROOT/examples
+    cd ${S}/examples
+    tar --no-same-owner \
+        --exclude='*.mpc'\
+        --exclude='*.o' \
+        --exclude='GNUmakefile*'\
+        --exclude='.gitignore'\
+        --exclude='.depend*'\
+        --exclude='.obj*'\
+        -cpf - . \
+        | tar --no-same-owner -xpf - -C ${D}${datadir}/DDS_ROOT/examples
+
+    # A symbolic link because the test script will search the execuables under DDS_ROOT.
+    # But because of the --prefix in the configure they are installed under /usr/bin
+    ln -s ${bindir} ${D}${datadir}/DDS_ROOT/bin
+    install -d ${D}/usr/lib/perl5/5.38.2/PerlACE
+    install -m 644 ${S}/ACE_wrappers/bin/PerlACE/*.pm ${D}/usr/lib/perl5/5.38.2/PerlACE
+    install -d ${D}/usr/lib/perl5/5.38.2/PerlDDS
+    install -m 644 ${S}/bin/PerlDDS/*.pm ${D}/usr/lib/perl5/5.38.2/PerlDDS
+    install -d ${D}${datadir}/DDS_ROOT/tools/scripts/modules
+    install -m 644 ${S}/tools/scripts/modules/*.pm ${D}${datadir}/DDS_ROOT/tools/scripts/modules
+}
+
 PACKAGES += "${PN}-ishapes"
 
 INSANE_SKIP:${PN} += "dev-so"
@@ -149,6 +214,7 @@ INSANE_SKIP:${PN}-dev += "libdir"
 
 FILES:${PN}-dev += "${datadir}"
 FILES:${PN}-ishapes += "${bindir}/ishapes"
+FILES:${PN}-ptest += "${libdir}/perl5/5.38.2/PerlACE ${libdir}/perl5/5.38.2/PerlDDS"
 
 ALLOW_EMPTY:${PN}-ishapes = "1"
 

--- a/recipes-connectivity/opendds/opendds/0002-gov-gen-uses-openssl-API-incorrectly.patch
+++ b/recipes-connectivity/opendds/opendds/0002-gov-gen-uses-openssl-API-incorrectly.patch
@@ -1,0 +1,58 @@
+From 5a9bc8545f771742e48d31e1635e15f156cc9c17 Mon Sep 17 00:00:00 2001
+From: "Justin R. Wilson" <wilsonj@unityfoundation.io>
+Date: Wed, 17 Apr 2024 12:59:03 -0500
+Subject: [PATCH] `gov_gen` uses openssl API incorrectly
+
+Problem
+-------
+
+The `gov_gen` application generates governance files for testing and
+signs them with openssl.  `gov_gen` has a bug on Debian
+12.5 (openssl 3.0.11) where a null argument is passed.
+
+Solution
+--------
+
+Pass `mem` as the "in"" parameter and use `PKCS7_STREAM`.
+
+Upstream-Status: Backport [https://github.com/OpenDDS/OpenDDS/commit/270cae56421462db367cbe8d89cccd752108dd20]
+
+---
+ docs/news.d/gov-gen.rst               | 5 +++++
+ tests/security/attributes/gov_gen.cpp | 4 ++--
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+ create mode 100644 docs/news.d/gov-gen.rst
+
+diff --git a/docs/news.d/gov-gen.rst b/docs/news.d/gov-gen.rst
+new file mode 100644
+index 0000000000..4a628c1659
+--- /dev/null
++++ b/docs/news.d/gov-gen.rst
+@@ -0,0 +1,5 @@
++.. news-prs: 4591
++
++.. news-start-section: Fixes
++- Fixed incorrect usage of OpenSSL in ``gov_gen`` application.
++.. news-end-section
+diff --git a/tests/security/attributes/gov_gen.cpp b/tests/security/attributes/gov_gen.cpp
+index ee1adbdf44..b35dd89ed4 100644
+--- a/tests/security/attributes/gov_gen.cpp
++++ b/tests/security/attributes/gov_gen.cpp
+@@ -403,7 +403,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
+     return EXIT_FAILURE;
+   }
+ 
+-  PKCS7* p7 = PKCS7_sign(cert, key, NULL, NULL, PKCS7_TEXT | PKCS7_DETACHED);
++  PKCS7* p7 = PKCS7_sign(cert, key, NULL, mem, PKCS7_TEXT | PKCS7_DETACHED | PKCS7_STREAM);
+   if (!p7) {
+     std::cerr << "ERROR: could not sign" << std::endl;
+     print_ssl_error();
+@@ -418,7 +418,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
+ 
+   }
+ 
+-  if (!SMIME_write_PKCS7(out, p7, mem, PKCS7_TEXT | PKCS7_DETACHED)) {
++  if (!SMIME_write_PKCS7(out, p7, mem, PKCS7_TEXT | PKCS7_DETACHED | PKCS7_STREAM)) {
+     std::cerr << "ERROR: could not write " << outpath << std::endl;
+     print_ssl_error();
+     return EXIT_FAILURE;

--- a/recipes-connectivity/opendds/opendds/run-ptest
+++ b/recipes-connectivity/opendds/opendds/run-ptest
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+export DDS_ROOT=/usr/share/DDS_ROOT
+export ACE_ROOT=/usr
+export TAO_ROOT=/usr
+export PERLLIB="$PERLLIB:/usr/share/DDS_ROOT/tools/scripts/modules"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DDS_ROOT/lib"
+LOG="/tmp/opendds_ptest_$(date +%Y%m%d-%H%M%S).log"
+
+# Todo: some sed experts can do their thing
+${DDS_ROOT}/tests/auto_run_tests.pl @PTEST_ARGS@ 2>&1 | tee -a ${LOG} | sed -rnu '/^auto_run_tests_finished:/p' | sed  -u 's/^auto_run_tests_finished: // ; /Result:0/ s/^/PASS: / ; /Result:0/! s/^/FAIL: /' | sed -u 's/\(.*\) \(Time:.*\) \(Result:.*\)/\1/'

--- a/recipes-connectivity/opendds/opendds_3.28.0.bb
+++ b/recipes-connectivity/opendds/opendds_3.28.0.bb
@@ -12,6 +12,7 @@ SRC_URI = "\
     git://github.com/OpenDDS/OpenDDS.git;protocol=https;branch=${DDS_SRC_BRANCH};name=opendds \
     ${@bb.utils.contains('PACKAGECONFIG', 'doc-group3', '${DOC_TAO3_URI};name=ace_tao;unpack=0;subdir=git', '${DOC_TAO2_URI};name=ace_tao;unpack=0;subdir=git', d)} \
     ${@bb.utils.contains('PACKAGECONFIG', 'ishapes', 'file://0001-adding-the-ishapes-demo.patch', '', d)} \
+    file://0002-gov-gen-uses-openssl-API-incorrectly.patch \
 "
 
 require opendds.inc


### PR DESCRIPTION
Hi,

A set of commits.  Could you review please.

1. a small update of the README.md file for the latest release.
2. Adding the Yocto ptest to the recipe.  With this it is possible to run the unit tests of OpenDDS into the framework of Yocto.
3. Adding my kas files to build and test the releases on Raspberry Pi 4 (ishapes & ptest.
    Kas is an easy and open source tool to make a Yocto image.
    Having them in the meta layer is rather common (e.g. meta-raspberrypi) and can later be used in the GitHub Actions.
    I will take a look later to have them or QEMU too.
    If this would work well for you, Kas could later be added into the OpenDDS documentation to replace or extend the Cross Compilation section.
4. I added for now the patch to solve the OpenSSL issue with the current version of Yocto.  The security tests went from failing to passing.