### PR TITLE
ptest + qemu

### DIFF
--- a/kas/README.md
+++ b/kas/README.md
@@ -25,11 +25,21 @@ git clone https://github.com/OpenDDS/meta-opendds.git
 Building
 --------
 
+### Rasberry Pi 4
+
 ```
 cd meta-opendds
-kas build kas/rpi.yaml; # Just OpenDDS for RPi
-kas build kas/rpi.yaml:kas/ishapes.yaml; # iShapes demo
-kas build kas/rpi.yaml:kas/ptests.yaml; # OpenDDS with Yocto ptests
+kas build kas/rpi.yaml:kas/opendds.yaml; # Just OpenDDS for RPi
+kas build kas/rpi.yaml:kas/opendds.yaml:kas/ishapes.yaml; # iShapes demo
+kas build kas/rpi.yaml:kas/opendds.yaml:kas/ptests.yaml; # OpenDDS with Yocto ptests
+```
+
+### Qemu
+
+```
+cd meta-opendds
+kas build kas/qemu.yaml:kas/opendds.yaml;
+kas build kas/qemu.yaml:kas/opendds.yaml:kas/ptests.yaml; # OpenDDS with Yocto ptests
 ```
 
 Deploying
@@ -47,14 +57,42 @@ sudo bmaptool copy core-image-minimal-xfce-raspberrypi4-64.rootfs.wic.bz2 /dev/s
 Testing
 -------
 
-### Run the ishapes demo
+### Raspberry Pi
+
+#### Run the ishapes demo
 
 Open a terminal on the Raspberry Pi.
 Run `ishapes`
 
-### Running the Yocto ptests for OpenDDS
+#### Running the Yocto ptests for OpenDDS
 
 Open a terminal on the Raspberry Pi.
 Run `ptest-runner opendds`
 
 A detailed log of the run can be found on the `/tmp` of the device.
+
+### qemu
+
+#### Start QEMU
+
+```
+kas sheel kas/qemu.yaml:kas/opendds.yaml:kas/ptests.yaml
+cd tmp/deploy/images/qemux86-64
+runqemu core-image-minimal-qemux86-64.rootfs.qemuboot.conf qemux86-64 nographic
+```
+
+#### Login
+
+* user root
+* no password
+
+#### Run the ptests
+
+```
+root@quemu-opendds:~# ptest-runner opendds
+```
+
+#### Exit
+
+```CTRL-a + x```
+

--- a/kas/opendds.yaml
+++ b/kas/opendds.yaml
@@ -1,0 +1,9 @@
+header:
+    version: 1
+
+local_conf_header:
+    opendds: |
+        IMAGE_INSTALL:append = " opendds"
+        PACKAGECONFIG:append:pn-opendds = " doc-group3"
+        PACKAGECONFIG:append:pn-opendds-native = " doc-group3"
+        INHERIT += "cve-check"

--- a/kas/qemu.yaml
+++ b/kas/qemu.yaml
@@ -1,18 +1,12 @@
 header:
     version: 1
 
-machine: raspberrypi4-64
+machine: qemux86-64
 
 distro: poky
 
-target: core-image-minimal-xfce
-
 repos:
     meta-opendds:
-    meta-raspberrypi:
-        url: https://github.com/agherzan/meta-raspberrypi
-        path: layers/meta-raspberrypi
-        branch: master  # Scartgap release not yet available
     poky:
         url: https://git.yoctoproject.org/git/poky
         path: layers/poky
@@ -29,9 +23,6 @@ repos:
             meta-python:
             meta-networking:
             meta-perl:
-            meta-gnome:
-            meta-multimedia:
-            meta-xfce:
 
 bblayers_conf_header:
     standard: |
@@ -59,7 +50,9 @@ local_conf_header:
             HALT,/tmp,10M,1K"
     network: |
         IMAGE_FEATURES:append = " ssh-server-openssh"
-        hostname:pn-base-files = "rpi4-opendds"
+        hostname:pn-base-files = "quemu-opendds"
     system: |
         DISTRO_FEATURES:append = " systemd usrmerge"
         VIRTUAL-RUNTIME_init_manager = "systemd"
+    qemu: |
+        QB_MEM = "-m 4096"

--- a/recipes-connectivity/opendds/opendds.inc
+++ b/recipes-connectivity/opendds/opendds.inc
@@ -9,6 +9,10 @@ inherit autotools ptest
 
 SRC_URI:append = " file://run-ptest"
 
+SRC_URI:append = " \
+    ${@bb.utils.contains('PACKAGECONFIG', 'tests', 'file://0003-tests-added-dependencies-to-run-all-tests.patch', '', d)} \
+    "
+
 PACKAGECONFIG ??= "security ${@bb.utils.contains('DISTRO_FEATURES', 'ptest', 'tests', '', d)}"
 PACKAGECONFIG:class-native ??= ""
 PACKAGECONFIG[security] = "--security, , openssl xerces-c, "
@@ -153,6 +157,10 @@ do_install_ptest() {
     tar --no-same-owner \
         --exclude='*.mpc'\
         --exclude='*.o' \
+        --exclude='*.h' \
+        --exclude='*.cpp' \
+        --exclude='*.idl' \
+        --exclude='*.inl' \
         --exclude='GNUmakefile*'\
         --exclude='.gitignore'\
         --exclude='.depend*'\
@@ -165,6 +173,10 @@ do_install_ptest() {
     tar --no-same-owner \
         --exclude='*.mpc'\
         --exclude='*.o' \
+        --exclude='*.h' \
+        --exclude='*.cpp' \
+        --exclude='*.idl' \
+        --exclude='*.inl' \
         --exclude='GNUmakefile*'\
         --exclude='.gitignore'\
         --exclude='.depend*'\
@@ -177,6 +189,10 @@ do_install_ptest() {
     tar --no-same-owner \
         --exclude='*.mpc'\
         --exclude='*.o' \
+        --exclude='*.h' \
+        --exclude='*.cpp' \
+        --exclude='*.idl' \
+        --exclude='*.inl' \
         --exclude='GNUmakefile*'\
         --exclude='.gitignore'\
         --exclude='.depend*'\
@@ -189,12 +205,20 @@ do_install_ptest() {
     tar --no-same-owner \
         --exclude='*.mpc'\
         --exclude='*.o' \
+        --exclude='*.h' \
+        --exclude='*.cpp' \
+        --exclude='*.idl' \
+        --exclude='*.inl' \
         --exclude='GNUmakefile*'\
         --exclude='.gitignore'\
         --exclude='.depend*'\
         --exclude='.obj*'\
         -cpf - . \
         | tar --no-same-owner -xpf - -C ${D}${datadir}/DDS_ROOT/examples
+
+    # tests do expect this excutable here
+    install -d ${D}${bindir}
+    install -m 755 ${S}/tools/repoctl/repoctl ${D}${bindir}
 
     # A symbolic link because the test script will search the execuables under DDS_ROOT.
     # But because of the --prefix in the configure they are installed under /usr/bin
@@ -205,6 +229,7 @@ do_install_ptest() {
     install -m 644 ${S}/bin/PerlDDS/*.pm ${D}/usr/lib/perl5/5.38.2/PerlDDS
     install -d ${D}${datadir}/DDS_ROOT/tools/scripts/modules
     install -m 644 ${S}/tools/scripts/modules/*.pm ${D}${datadir}/DDS_ROOT/tools/scripts/modules
+
 }
 
 PACKAGES += "${PN}-ishapes"

--- a/recipes-connectivity/opendds/opendds/0003-tests-added-dependencies-to-run-all-tests.patch
+++ b/recipes-connectivity/opendds/opendds/0003-tests-added-dependencies-to-run-all-tests.patch
@@ -1,0 +1,29 @@
+From 560c6ec8a3d0073b0a1d01c1148bb4c104ce6a1a Mon Sep 17 00:00:00 2001
+From: Jan Vermaete <jan.vermaete@gmail.com>
+Date: Sun, 28 Apr 2024 13:03:37 +0200
+Subject: [PATCH 3/3] tests: added dependencies to run all tests
+
+Upstream-Status: Inappropriate [enable feature]
+
+Signed-off-by: Jan Vermaete <jan.vermaete@gmail.com>
+---
+ DDS_TAOv2.mwc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/DDS_TAOv2.mwc b/DDS_TAOv2.mwc
+index 384e2620a..a337a9190 100644
+--- a/DDS_TAOv2.mwc
++++ b/DDS_TAOv2.mwc
+@@ -6,6 +6,9 @@ workspace {
+   tools
+   java
+   DevGuideExamples
++  // Needed for testing
++  $(TAO_ROOT)/orbsvcs/ImplRepo_Service/ImplRepo_Service.mpc
++  $(TAO_ROOT)/orbsvcs/Naming_Service/Naming_Service.mpc
+ 
+   exclude {
+     java/jms
+-- 
+2.39.2
+

--- a/recipes-connectivity/opendds/opendds/0010-WIP-test-filter-tests-that-should-not-run-on-the-tar.patch
+++ b/recipes-connectivity/opendds/opendds/0010-WIP-test-filter-tests-that-should-not-run-on-the-tar.patch
@@ -1,0 +1,48 @@
+From c41ea08127d8cda6b95c828089b8f1df74335a14 Mon Sep 17 00:00:00 2001
+From: Jan Vermaete <jan.vermaete@gmail.com>
+Date: Wed, 24 Apr 2024 20:32:45 +0200
+Subject: [PATCH 10/10] WIP: test: filter tests that should not run on the
+ target
+
+Do not the tests marked with !CROSS_COMPILED
+
+These tests are skipped when running the OpenDDS testsuite on a target.
+
+Upstream-Status: Pending
+
+Signed-off-by: Jan Vermaete <jan.vermaete@gmail.com>
+---
+ tests/dcps_tests.lst | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tests/dcps_tests.lst b/tests/dcps_tests.lst
+index efe998a25..7a0040014 100644
+--- a/tests/dcps_tests.lst
++++ b/tests/dcps_tests.lst
+@@ -77,12 +77,12 @@ tests/DCPS/Compiler/is_topic_type/run_test.pl: !DCPS_MIN
+ tests/DCPS/Compiler/vread_vwrite/run_test.pl: !DCPS_MIN RAPIDJSON CXX11
+ tests/DCPS/Compiler/TryConstruct/run_test.pl: !DCPS_MIN
+ tests/DCPS/Compiler/TryConstruct/C++11/run_test.pl: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE
+-tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
++tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !CROSS_COMPILED
+ tests/DCPS/Compiler/xcdr/run_test.pl
+ tests/DCPS/Compiler/xcdr/run_test.pl --dynamic: !OPENDDS_SAFETY_PROFILE !DDS_NO_CONTENT_SUBSCRIPTION
+ tests/DCPS/Compiler/XtypesExtensibility/run_test.pl: !DCPS_MIN
+ tests/DCPS/Compiler/typeobject_generator/run_test.pl
+-tests/DCPS/Compiler/keywords/run_test.pl classic: !DCPS_MIN
++tests/DCPS/Compiler/keywords/run_test.pl classic: !DCPS_MIN !CROSS_COMPILED
+ tests/DCPS/Compiler/keywords/run_test.pl cpp11: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE
+ tests/DCPS/Compiler/explicit_ints/run_test.pl classic: !DCPS_MIN
+ tests/DCPS/Compiler/explicit_ints/run_test.pl cpp11: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE
+@@ -266,7 +266,7 @@ tests/stress-tests/run_test.pl: !DCPS_MIN !NO_UNIT_TESTS
+ tests/DCPS/KeyTest/run_test.pl keymarshalling: !DCPS_MIN
+ tests/DCPS/KeyTest/run_test.pl isbounded: !DCPS_MIN
+ tests/DCPS/KeyTest/run_test.pl md5: !DCPS_MIN
+-tests/DCPS/KeyTest/run_test.pl compiler: !DCPS_MIN !TARGET !OPENDDS_SAFETY_PROFILE
++tests/DCPS/KeyTest/run_test.pl compiler: !DCPS_MIN !TARGET !OPENDDS_SAFETY_PROFILE  !CROSS_COMPILED
+ tests/DCPS/CompatibilityTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
+ tests/DCPS/CompatibilityTest/run_test.pl rtps_disc: !DCPS_MIN RTPS !GH_ACTIONS_M10
+ tests/DCPS/CompatibilityTest/run_test.pl rtps_disc_tcp: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE
+-- 
+2.39.2
+

--- a/recipes-connectivity/opendds/opendds/run-ptest
+++ b/recipes-connectivity/opendds/opendds/run-ptest
@@ -1,11 +1,23 @@
 #!/bin/sh
 
 export DDS_ROOT=/usr/share/DDS_ROOT
-export ACE_ROOT=/usr
-export TAO_ROOT=/usr
-export PERLLIB="$PERLLIB:/usr/share/DDS_ROOT/tools/scripts/modules"
+export ACE_ROOT=$DDS_ROOT/ACE_wrappers
+export TAO_ROOT=$DDS_ROOT/ACE_wrappers/TAO/
+export PERLLIB="$PERLLIB:$DDS_ROOT/tools/scripts/modules"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DDS_ROOT/lib"
-LOG="/tmp/opendds_ptest_$(date +%Y%m%d-%H%M%S).log"
+LOG_LONG="/tmp/opendds_ptest_$(date +%Y%m%d-%H%M%S).log"
+LOG_SHORT="/tmp/opendds_ptest_short_$(date +%Y%m%d-%H%M%S).log"
 
-# Todo: some sed experts can do their thing
-${DDS_ROOT}/tests/auto_run_tests.pl @PTEST_ARGS@ 2>&1 | tee -a ${LOG} | sed -rnu '/^auto_run_tests_finished:/p' | sed  -u 's/^auto_run_tests_finished: // ; /Result:0/ s/^/PASS: / ; /Result:0/! s/^/FAIL: /' | sed -u 's/\(.*\) \(Time:.*\) \(Result:.*\)/\1/'
+${DDS_ROOT}/tests/auto_run_tests.pl @PTEST_ARGS@ -Config CROSS_COMPILED 2>&1 | tee -a ${LOG_LONG} | sed -rnu '/^auto_run_tests_finished:/p' | sed  -u 's/^auto_run_tests_finished: // ; /Result:0/ s/^/PASS: / ; /Result:0/! s/^/FAIL: /' | sed -u 's/\(.*\) \(Time:.*\) \(Result:.*\)/\1/' | tee -a ${LOG_SHORT}
+
+passed=`grep PASS: ${LOG_SHORT}|wc -l`
+failed=`grep FAIL: ${LOG_SHORT}|wc -l`
+all=$((passed + failed))
+
+echo "=== Test Summary ==="
+echo "TOTAL: ${all}"
+echo "PASSED: ${passed}"
+echo "FAILED: ${failed}"
+
+exit ${failed}
+~

--- a/recipes-connectivity/opendds/opendds_3.28.0.bb
+++ b/recipes-connectivity/opendds/opendds_3.28.0.bb
@@ -13,6 +13,7 @@ SRC_URI = "\
     ${@bb.utils.contains('PACKAGECONFIG', 'doc-group3', '${DOC_TAO3_URI};name=ace_tao;unpack=0;subdir=git', '${DOC_TAO2_URI};name=ace_tao;unpack=0;subdir=git', d)} \
     ${@bb.utils.contains('PACKAGECONFIG', 'ishapes', 'file://0001-adding-the-ishapes-demo.patch', '', d)} \
     file://0002-gov-gen-uses-openssl-API-incorrectly.patch \
+    file://0010-WIP-test-filter-tests-that-should-not-run-on-the-tar.patch \
 "
 
 require opendds.inc


### PR DESCRIPTION
Hi,

First commit is to have the testsuite of OpenDDS inside the test framework of Yocto.
And filter the tests that should not run on the cross compiled target.

Second commit is to have an image with OpenDDS (and ptest) that could run in the QEMU emulation.
Building of it is also documented in the readme file under the kas directory.

Note that some one test is failing under qemu.
tests/DCPS/QueryCondition/run_test.pl rtps_disc dynamic
For now I assume due to my lack of compute power.

br